### PR TITLE
chore: drop python 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 packages = [{include = "solutions"}]
 
 [tool.poetry.dependencies]
-python = ">=3.10,<4.0.0"
+python = ">=3.11,<4.0.0"
 numpy = "2.2.6"
 networkx = "3.4.2"
 


### PR DESCRIPTION
This is needed for #168.